### PR TITLE
feat(tray): add log and repo links with config editing

### DIFF
--- a/internal/logs/paths_test.go
+++ b/internal/logs/paths_test.go
@@ -42,7 +42,7 @@ func TestOSSpecificLogDirs(t *testing.T) {
 		{
 			name:     "Linux",
 			os:       "linux",
-			expected: []string{"mcpproxy", "logs"},
+			expected: []string{"mcpproxy", "log"},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- sort upstream servers in the tray by status and track log/repo items
- add per-server actions to open logs and repositories
- allow editing config file directly from tray and adjust Linux log path test

## Testing
- `go test ./internal/tray -v`
- `go test ./internal/logs -run TestOSSpecificLogDirs -v`
- `go test ./internal/... -v`


------
https://chatgpt.com/codex/tasks/task_b_68c6d073351c8321a6ff25a6afc56ee4